### PR TITLE
Fix some rendering issues in the markdown version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ Example 1.1.1.
 Vectors are often written vertically in column form, which emphasizes their role in matrix multiplication:
 
 $$
-\mathbf{v} = \begin{bmatrix} 2 \\ 0 \\ 5 \end{bmatrix} \in \mathbb{R}^3.
+\mathbf{v} = \begin{bmatrix}
+2 \\
+0 \\ 
+5 \end{bmatrix} \in \mathbb{R}^3.
 $$
 
 The vertical layout makes the structure clearer when we consider linear combinations or multiply matrices by vectors.
@@ -367,7 +370,7 @@ where $(2,0)$ is parallel to $(1,0)$ and $(0,3)$ is orthogonal to it.
 In general, if $\mathbf{u} \neq \mathbf{0}$ and $\mathbf{v} \in \mathbb{R}^n$, then
 
 $$
-\mathbf{v} = \text{proj}_{\mathbf{u}}(\mathbf{v}) + \big(\mathbf{v} - \text{proj}_{\mathbf{u}}(\mathbf{v})\big),
+\mathbf{v} = \text{proj}\_{\mathbf{u}}(\mathbf{v}) + \big(\mathbf{v} - \text{proj}\_{\mathbf{u}}(\mathbf{v})\big),
 $$
 
 where the first term is parallel to $\mathbf{u}$ and the second term is orthogonal. This decomposition underlies methods
@@ -471,7 +474,7 @@ single compact object can represent both numerical data and functional rules.
 2. Is every vector a matrix? Is every matrix a vector? Explain.
 3. Which of the following are square
    matrices: $A \in \mathbb{R}^{4\times4}$, $B \in \mathbb{R}^{3\times5}$, $C \in \mathbb{R}^{1\times1}$?
-4. Let $D = \begin{bmatrix} 1 & 0 \\ 0 & 1 \end{bmatrix}$. What kind of matrix is this?
+4. Let $D = \begin{bmatrix} 1 & 0 \\\\ 0 & 1 \end{bmatrix}$. What kind of matrix is this?
 5. Consider the matrix $E = \begin{bmatrix} a & b \\ c & d \end{bmatrix}$. Express $e_{11}, e_{12}, e_{21}, e_{22}$
    explicitly.
 
@@ -515,8 +518,7 @@ $$
 A + B = \begin{bmatrix}
 1 + (-1) & 2 + 0 \\
 3 + 5 & 4 + 2
-\end{bmatrix}
-=
+\end{bmatrix} =
 \begin{bmatrix}
 0 & 2 \\
 8 & 6
@@ -592,8 +594,7 @@ $$
 AB = \begin{bmatrix}
 1\cdot4 + 2\cdot2 & 1\cdot(-1) + 2\cdot5 \\
 0\cdot4 + 3\cdot2 & 0\cdot(-1) + 3\cdot5
-\end{bmatrix}
-=
+\end{bmatrix} =
 \begin{bmatrix}
 8 & 9 \\
 6 & 15
@@ -627,21 +628,27 @@ networks.
 1. Compute $A+B$ for
 
 $$
-A = \begin{bmatrix} 2 & 3 \\ -1 & 0 \end{bmatrix}, \quad
-B = \begin{bmatrix} 4 & -2 \\ 5 & 7 \end{bmatrix}.
+A = \begin{bmatrix} 2 & 3 \\
+-1 & 0 \end{bmatrix}, \quad
+B = \begin{bmatrix} 4 & -2 \\
+5 & 7 \end{bmatrix}.
 $$
 
 2. Find $3A$ where
 
 $$
-A = \begin{bmatrix} 1 & -4 \\ 2 & 6 \end{bmatrix}.
+A = \begin{bmatrix} 1 & -4 \\
+2 & 6 \end{bmatrix}.
 $$
 
 3. Multiply
 
 $$
-A = \begin{bmatrix} 1 & 0 & 2 \\ -1 & 3 & 1 \end{bmatrix}, \quad
-B = \begin{bmatrix} 2 & 1 \\ 0 & -1 \\ 3 & 4 \end{bmatrix}.
+A = \begin{bmatrix} 1 & 0 & 2 \\
+-1 & 3 & 1 \end{bmatrix}, \quad
+B = \begin{bmatrix} 2 & 1 \\
+0 & -1 \\
+3 & 4 \end{bmatrix}.
 $$
 
 4. Verify with an explicit example that $AB \neq BA$.
@@ -661,7 +668,7 @@ rows and columns.
 Formally,
 
 $$
-(A^T)_{ij} = a_{ji}.
+(A^T)\_{ij} = a\_{ji}.
 $$
 
 Example 2.3.1.
@@ -686,10 +693,10 @@ $$
 
 Properties of the Transpose.
 
-1. $ (A^T)^T = A$.
-2. $ (A+B)^T = A^T + B^T$.
-3. $ (cA)^T = cA^T$, for scalar $c$.
-4. $ (AB)^T = B^T A^T$.
+1. $(A^T)^T = A$.
+2. $(A+B)^T = A^T + B^T$.
+3. $(cA)^T = cA^T$, for scalar $c$.
+4. $(AB)^T = B^T A^T$.
 
 The last rule is crucial: the order reverses.
 
@@ -723,8 +730,7 @@ $$
 A^{-1} = \frac{1}{\det(A)} \begin{bmatrix}
 4 & -2 \\
 -3 & 1
-\end{bmatrix}
-=
+\end{bmatrix} =
 \begin{bmatrix}
 -2 & 1 \\
 1.5 & -0.5
@@ -741,8 +747,7 @@ AA^{-1} = \begin{bmatrix}
 \begin{bmatrix}
 -2 & 1 \\
 1.5 & -0.5
-\end{bmatrix}
-=
+\end{bmatrix} =
 \begin{bmatrix}
 1 & 0 \\
 0 & 1
@@ -779,14 +784,20 @@ $$
 2. Verify that $(AB)^T = B^T A^T$ for
 
 $$
-A = \begin{bmatrix} 1 & 2 \\ 0 & 1 \end{bmatrix}, \quad
-B = \begin{bmatrix} 3 & 4 \\ 5 & 6 \end{bmatrix}.
+A = \begin{bmatrix}
+1 & 2 \\
+0 & 1 \end{bmatrix}, \quad
+B = \begin{bmatrix} 
+3 & 4 \\
+5 & 6 \end{bmatrix}.
 $$
 
 3. Determine whether
 
 $$
-C = \begin{bmatrix} 2 & 1 \\ 4 & 2 \end{bmatrix}
+C = \begin{bmatrix}
+2 & 1 \\
+4 & 2 \end{bmatrix}
 $$
 
 is invertible. If so, find $C^{-1}$.
@@ -794,7 +805,9 @@ is invertible. If so, find $C^{-1}$.
 4. Find the inverse of
 
 $$
-D = \begin{bmatrix} 0 & 1 \\ -1 & 0 \end{bmatrix},
+D = \begin{bmatrix}
+0 & 1 \\
+-1 & 0 \end{bmatrix},
 $$
 
 and explain its geometric action on vectors in the plane.
@@ -850,14 +863,22 @@ Example 2.4.1.
 Let
 
 $$
-D = \begin{bmatrix} 2 & 0 & 0 \\ 0 & 3 & 0 \\ 0 & 0 & -1 \end{bmatrix}, \quad
-\mathbf{x} = \begin{bmatrix} 1 \\ 4 \\ -2 \end{bmatrix}.
+D = \begin{bmatrix} 2 & 0 & 0 \\
+0 & 3 & 0 \\
+0 & 0 & -1 \end{bmatrix}, \quad
+\mathbf{x} = \begin{bmatrix} 
+1 \\
+4 \\
+-2 \end{bmatrix}.
 $$
 
 Then
 
 $$
-D\mathbf{x} = \begin{bmatrix} 2 \\ 12 \\ 2 \end{bmatrix}.
+D\mathbf{x} = \begin{bmatrix} 
+2 \\
+12 \\
+2 \end{bmatrix}.
 $$
 
 ### Permutation Matrices
@@ -879,8 +900,13 @@ $$
 Then
 
 $$
-P\begin{bmatrix} a \\ b \\ c \end{bmatrix} =
-\begin{bmatrix} b \\ a \\ c \end{bmatrix}.
+P\begin{bmatrix} 
+a \\
+b \\
+c \end{bmatrix} =
+\begin{bmatrix} b \\
+a \\
+c \end{bmatrix}.
 $$
 
 Thus, $P$ swaps the first two coordinates.
@@ -946,15 +972,21 @@ these simple forms.
 4. Verify that
 
 $$
-Q = \begin{bmatrix} 0 & 1 \\ -1 & 0 \end{bmatrix}
+Q = \begin{bmatrix} 
+0 & 1 \\
+-1 & 0 \end{bmatrix}
 $$
 
 is orthogonal. What geometric transformation does it represent?
 5\. Determine whether
 
 $$
-A = \begin{bmatrix} 2 & 3 \\ 3 & 2 \end{bmatrix}, \quad
-B = \begin{bmatrix} 0 & 5 \\ -5 & 0 \end{bmatrix}
+A = \begin{bmatrix}
+2 & 3 \\
+3 & 2 \end{bmatrix}, \quad
+B = \begin{bmatrix}
+0 & 5 \\
+-5 & 0 \end{bmatrix}
 $$
 
 are symmetric, skew-symmetric, or neither.
@@ -1013,8 +1045,7 @@ can be written as
 
 $$
 \begin{bmatrix} 1 & 2 \\ 3 & -1 \end{bmatrix}
-\begin{bmatrix} x \\ y \end{bmatrix}
-=
+\begin{bmatrix} x \\ y \end{bmatrix} =
 \begin{bmatrix} 5 \\ 4 \end{bmatrix}.
 $$
 
@@ -2007,7 +2038,7 @@ these transformations, their representations, and their invariants.
 5. Let $T:\mathbb{R}[x] \to \mathbb{R}[x]$ be integration:
 
    $$
-   T(p(x)) = \int_0^x p(t)\,dt.
+   T(p(x)) = \int_0^x p(t)\\,dt.
    $$
 
    Prove that $T$ is a linear transformation.
@@ -2027,7 +2058,11 @@ and 0 elsewhere.
 The action of $T$ on each basis vector determines the entire transformation:
 
 $$
-T(\mathbf{e}_j) = \begin{bmatrix} a_{1j} \\ a_{2j} \\ \vdots \\ a_{mj} \end{bmatrix}.
+T(\mathbf{e}\_j) = \begin{bmatrix} 
+a_{1j} \\ 
+a_{2j} \\ 
+\vdots \\ 
+a_{mj} \end{bmatrix}.
 $$
 
 Placing these outputs as columns gives the matrix of $T$:
@@ -3128,7 +3163,7 @@ After normalization, it becomes an orthonormal basis.
    $$
 
 3. Projections:
-   The orthogonal projection onto the span of $\{\mathbf{u}_1,\dots,\mathbf{u}_k\}$ is
+   The orthogonal projection onto the span of $\\{\mathbf{u}_1,\dots,\mathbf{u}_k\\}$ is
 
    $$
    \text{proj}(\mathbf{v}) = \sum_{i=1}^k \langle \mathbf{v}, \mathbf{u}_i \rangle \mathbf{u}_i.
@@ -3153,10 +3188,10 @@ produces orthonormal directions capturing maximum variance.
 
 ### Exercises 7.4
 
-1. Verify that $(1/\sqrt{2})(1,1)$ and $(1/\sqrt{2})(1,-1)$ form an orthonormal basis of $\mathbb{R}^2$.
-2. Express $(3,4)$ in terms of the orthonormal basis $\{(1/\sqrt{2})(1,1), (1/\sqrt{2})(1,-1)\}$.
-3. Prove Parseval’s identity for $\mathbb{R}^n$ with the dot product.
-4. Find an orthonormal basis for the plane $x+y+z=0$ in $\mathbb{R}^3$.
+1. Verify that $(1/\\sqrt{2})(1,1)$ and $(1/\\sqrt{2})(1,-1)$ form an orthonormal basis of $\mathbb{R}^2$.
+2. Express $(3,4)$ in terms of the orthonormal basis $\{(1/\\sqrt{2})(1,1), (1/\\sqrt{2})(1,-1)\}$.
+3. Prove Parseval’s identity for $\\mathbb{R}^n$ with the dot product.
+4. Find an orthonormal basis for the plane $x+y+z=0$ in $\\mathbb{R}^3$.
 5. Explain why orthonormal bases are numerically more stable than arbitrary bases in computations.
 
 # Chapter 8. Eigenvalues and eigenvectors

--- a/README.md
+++ b/README.md
@@ -3553,7 +3553,9 @@ Example 8.4.1.
 Let
 
 $$
-A = \begin{bmatrix} 2 & 0 \\ 0 & -1 \end{bmatrix}.
+A = \begin{bmatrix}
+2 & 0 \\
+0 & -1 \end{bmatrix}.
 $$
 
 Then eigenvalues are $2, -1$ with eigenvectors $(1,0)$, $(0,1)$. Solutions are
@@ -3588,7 +3590,9 @@ Example 8.4.2.
 Consider
 
 $$
-P = \begin{bmatrix} 0.9 & 0.5 \\ 0.1 & 0.5 \end{bmatrix}.
+P = \begin{bmatrix}
+0.9 & 0.5 \\
+0.1 & 0.5 \end{bmatrix}.
 $$
 
 Eigenvalues are $\lambda_1 = 1$, $\lambda_2 = 0.4$. The eigenvector for $\lambda = 1$ is proportional to $(5,1)$.
@@ -3654,13 +3658,21 @@ Example 9.1.1.
 For
 
 $$
-A = \begin{bmatrix} 2 & 1 \\ 1 & 3 \end{bmatrix}, \quad \mathbf{x} = \begin{bmatrix} x \\ y \end{bmatrix},
+A = \begin{bmatrix}
+2 & 1 \\
+1 & 3 \end{bmatrix}, \quad \mathbf{x} = \begin{bmatrix}
+x \\
+y \end{bmatrix},
 $$
 
 $$
 Q(x,y) = \begin{bmatrix} x & y \end{bmatrix}
-\begin{bmatrix} 2 & 1 \\ 1 & 3 \end{bmatrix}
-\begin{bmatrix} x \\ y \end{bmatrix}
+\begin{bmatrix}
+2 & 1 \\
+1 & 3 \end{bmatrix}
+\begin{bmatrix}
+x \\
+y \end{bmatrix}
 = 2x^2 + 2xy + 3y^2.
 $$
 
@@ -3683,7 +3695,10 @@ $$
 is described by the quadratic form $\mathbf{x}^T A \mathbf{x} = 1$ with
 
 $$
-A = \begin{bmatrix} 4 & 1 \\ 1 & 5 \end{bmatrix}.
+A = \begin{bmatrix}
+4 & 1 \\
+1 & 5
+\end{bmatrix}.
 $$
 
 ### Diagonalization of Quadratic Forms
@@ -3755,7 +3770,9 @@ Similarly, negative definite (always < 0) and indefinite (can be both < 0 and > 
 Example 9.2.1.
 
 $$
-A = \begin{bmatrix} 2 & 0 \\ 0 & 3 \end{bmatrix}
+A = \begin{bmatrix}
+2 & 0 \\
+0 & 3 \end{bmatrix}
 $$
 
 is positive definite, since
@@ -3769,7 +3786,9 @@ for all $(x,y) \neq (0,0)$.
 Example 9.2.2.
 
 $$
-A = \begin{bmatrix} 1 & 2 \\ 2 & 1 \end{bmatrix}
+A = \begin{bmatrix}
+1 & 2 \\
+2 & 1 \end{bmatrix}
 $$
 
 has quadratic form
@@ -3875,7 +3894,9 @@ If $A \in \mathbb{R}^{n \times n}$ is symmetric ($A^T = A$), then:
 Let
 
 $$
-A = \begin{bmatrix} 2 & 1 \\ 1 & 2 \end{bmatrix}.
+A = \begin{bmatrix}
+2 & 1 \\
+1 & 2 \end{bmatrix}.
 $$
 
 1. Characteristic polynomial:
@@ -3900,8 +3921,15 @@ $$
 4. Then
 
 $$
-Q = \begin{bmatrix} \tfrac{1}{\sqrt{2}} & \tfrac{1}{\sqrt{2}} \[6pt] -\tfrac{1}{\sqrt{2}} & \tfrac{1}{\sqrt{2}} \end{bmatrix}, \quad
-\Lambda = \begin{bmatrix} 1 & 0 \\ 0 & 3 \end{bmatrix}.
+Q = 
+\begin{bmatrix}
+\tfrac{1}{\sqrt{2}} & \tfrac{1}{\sqrt{2}} \[6pt] -\tfrac{1}{\sqrt{2}} & \tfrac{1}{\sqrt{2}} 
+\end{bmatrix}, \quad
+\Lambda = 
+\begin{bmatrix}
+1 & 0 \\
+0 & 3
+\end{bmatrix}.
 $$
 
 So
@@ -3985,7 +4013,11 @@ Suppose we have two-dimensional data points roughly aligned along the line $y = 
 approximately
 
 $$
-\Sigma = \begin{bmatrix} 2 & 1.9 \\ 1.9 & 2 \end{bmatrix}.
+\Sigma = 
+\begin{bmatrix}
+2 & 1.9 \\
+1.9 & 2
+\end{bmatrix}.
 $$
 
 Eigenvalues are about $3.9$ and $0.1$. The eigenvector for $\lambda = 3.9$ is approximately $(1,1)/\sqrt{2}$.
@@ -4189,9 +4221,17 @@ x_2 & 1 \\
 x_m & 1
 \end{bmatrix},
 \quad
-\mathbf{b} = \begin{bmatrix} y_1 \\ y_2 \\ \vdots \\ y_m \end{bmatrix},
+\mathbf{b} = 
+\begin{bmatrix}
+y_1 \\ 
+y_2 \\ 
+\vdots \\
+y_m \end{bmatrix},
 \quad
-\mathbf{x} = \begin{bmatrix} m \\ c \end{bmatrix}.
+\mathbf{x} =
+\begin{bmatrix}
+m \\
+c \end{bmatrix}.
 $$
 
 Solve $A^T A \mathbf{x} = A^T \mathbf{b}$. This yields the best-fit line in the least squares sense.
@@ -4248,7 +4288,7 @@ $$
 L = D - A,
 $$
 
-where $D$ is the diagonal degree matrix ($D_{ii} = \text{degree}(i)$).
+where $D$ is the diagonal degree matrix ( $D_{ii} = \text{degree}(i)$ ).
 
 * $L$ is symmetric and positive semidefinite.
 * The smallest eigenvalue is always $0$, with eigenvector $(1,1,\dots,1)$.
@@ -4325,13 +4365,12 @@ A dataset with $m$ examples and $n$ features is represented as a matrix $X \in \
 $$
 X =
 \begin{bmatrix}
-
-- & \mathbf{x}_1^T & - \\
-- & \mathbf{x}_2^T & - \\
+\- & \mathbf{x}_1^T & - \\
+\- & \mathbf{x}_2^T & - \\
   & \vdots & \\
-- & \mathbf{x}_m^T & -
-  \end{bmatrix},
-  $$
+\- & \mathbf{x}_m^T & -
+\end{bmatrix},
+$$
 
 where each row $\mathbf{x}_i \in \mathbb{R}^n$ is a feature vector. Linear algebra provides tools to analyze, compress,
 and transform this data.
@@ -4340,16 +4379,12 @@ and transform this data.
 
 At the heart of machine learning are linear predictors:
 
-$$
-\hat{y} = X\mathbf{w},
-$$
+$$\hat{y} = X\mathbf{w},$$
 
 where $\mathbf{w}$ is the weight vector. Training often involves solving a least squares problem or a regularized
 variant such as ridge regression:
 
-$$
-\min_{\mathbf{w}} \|X\mathbf{w} - \mathbf{y}\|^2 + \lambda \|\mathbf{w}\|^2.
-$$
+$$\min_{\mathbf{w}} \|X\mathbf{w} - \mathbf{y}\|^2 + \lambda \|\mathbf{w}\|^2.$$
 
 This is solved efficiently using matrix factorizations.
 
@@ -4357,9 +4392,7 @@ This is solved efficiently using matrix factorizations.
 
 The SVD of a matrix $X$ is
 
-$$
-X = U \Sigma V^T,
-$$
+$$X = U \Sigma V^T,$$
 
 where $U, V$ are orthogonal and $\Sigma$ is diagonal with nonnegative entries (singular values).
 
@@ -4397,7 +4430,7 @@ be intractable.
 
 2. Explain how SVD can be used to compress an image represented as a matrix of pixel intensities.
 
-3. For a covariance matrix $\Sigma$, show why its eigenvalues represent variances along principal components.
+3. For a covariance matrix $\\Sigma$, show why its eigenvalues represent variances along principal components.
 
 4. Give an example of how eigenvectors of the Laplacian matrix can be used for clustering a small graph.
 

--- a/README.md
+++ b/README.md
@@ -4430,7 +4430,7 @@ be intractable.
 
 2. Explain how SVD can be used to compress an image represented as a matrix of pixel intensities.
 
-3. For a covariance matrix $\\Sigma$, show why its eigenvalues represent variances along principal components.
+3. For a covariance matrix $\Sigma$, show why its eigenvalues represent variances along principal components.
 
 4. Give an example of how eigenvectors of the Laplacian matrix can be used for clustering a small graph.
 


### PR DESCRIPTION
Addresses https://github.com/the-litte-book-of/linear-algebra/issues/1 and https://github.com/the-litte-book-of/linear-algebra/issues/3 among other things.

The other "Unable to render expression" errors starting from Example 7.3.1 cannot be fixed it seems without converting the main README.md into smaller files.